### PR TITLE
Porto Theme fix when upgrading to Magento 2.3.4.

### DIFF
--- a/app/design/frontend/Smartwave/porto/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
+++ b/app/design/frontend/Smartwave/porto/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
@@ -8,7 +8,8 @@
 //  _____________________________________________
 
 @checkout-tooltip__hover__z-index: @tooltip__z-index;
-@checkout-tooltip-breakpoint__screen-m: @modal-popup-breakpoint-screen__m;
+//@checkout-tooltip-breakpoint__screen-m: @modal-popup-breakpoint-screen__m;
+@checkout-tooltip-breakpoint__screen-m: @screen__m;
 
 @checkout-tooltip-icon-arrow__font-size: 10px;
 @checkout-tooltip-icon-arrow__left: -( @checkout-tooltip-content__padding + @checkout-tooltip-icon-arrow__font-size - @checkout-tooltip-content__border-width);

--- a/app/design/frontend/Smartwave/porto_rtl/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
+++ b/app/design/frontend/Smartwave/porto_rtl/Magento_Checkout/web/css/source/module/checkout/_tooltip.less
@@ -8,7 +8,8 @@
 //  _____________________________________________
 
 @checkout-tooltip__hover__z-index: @tooltip__z-index;
-@checkout-tooltip-breakpoint__screen-m: @modal-popup-breakpoint-screen__m;
+//@checkout-tooltip-breakpoint__screen-m: @modal-popup-breakpoint-screen__m;
+@checkout-tooltip-breakpoint__screen-m: @screen__m;
 
 @checkout-tooltip-icon-arrow__font-size: 10px;
 @checkout-tooltip-icon-arrow__left: -( @checkout-tooltip-content__padding + @checkout-tooltip-icon-arrow__font-size - @checkout-tooltip-content__border-width);


### PR DESCRIPTION
Needed to avoid Less compilation error files (styles-l.css and styles-m.css are not generated).